### PR TITLE
Set proper name for main javascript file in package configs

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ng-feathers",
   "description": "Feathers client for AngularJS",
-  "main": "index.js",
+  "main": "src/ng-feathers.js",
   "authors": [
     "Maik Hummel <m@ikhummel.com> (https://beevelop.com)"
   ],

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ng-feathers",
   "version": "1.7.2",
   "description": "Feathers client for AngularJS",
-  "main": "index.js",
+  "main": "src/ng-feathers.js",
   "scripts": {
     "test": "grunt",
     "clean": "rm -r bower_components/ node_modules/",


### PR DESCRIPTION
Automated build tools (Grunt in my case) cannot properly detect main sources of package, because
invalid `index.js` file is specified in `main` section of package configs